### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
       - '*'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/notomo/gh-issue-create-deduped/security/code-scanning/2](https://github.com/notomo/gh-issue-create-deduped/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is scoped minimally.  
Best fix here: define workflow-level permissions right after the triggers (`on:` block) and before `jobs:` so all jobs inherit it unless overridden. For the shown workflow, the minimal safe baseline is:

- `contents: read`

This preserves existing behavior for checkout and read operations while preventing unintended write capabilities from default settings. No imports, methods, or additional definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
